### PR TITLE
[feat] API 베이스 작업

### DIFF
--- a/Someverse/Core/Network/DTO/AnnouncementDTO.swift
+++ b/Someverse/Core/Network/DTO/AnnouncementDTO.swift
@@ -1,0 +1,88 @@
+//
+//  AnnouncementDTO.swift
+//  Someverse
+//
+//  Created by 박채현 on 12/10/25.
+//
+
+import Foundation
+
+// MARK: - Announcement List Response
+
+struct AnnouncementListResponse: Decodable {
+  let announcements: [AnnouncementDTO]
+  let pageInfo: PageInfo?
+
+  enum CodingKeys: String, CodingKey {
+    case announcements
+    case pageInfo
+  }
+}
+
+// MARK: - Announcement DTO
+
+struct AnnouncementDTO: Decodable {
+  let id: Int
+  let title: String
+  let content: String
+  let category: String?
+  let isPinned: Bool
+  let viewCount: Int?
+  let createdAt: String
+  let updatedAt: String?
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case title
+    case content
+    case category
+    case isPinned
+    case viewCount
+    case createdAt
+    case updatedAt
+  }
+}
+
+// MARK: - Announcement Detail Response
+
+struct AnnouncementDetailResponse: Decodable {
+  let id: Int
+  let title: String
+  let content: String
+  let category: String?
+  let isPinned: Bool
+  let viewCount: Int
+  let attachments: [AttachmentDTO]?
+  let createdAt: String
+  let updatedAt: String?
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case title
+    case content
+    case category
+    case isPinned
+    case viewCount
+    case attachments
+    case createdAt
+    case updatedAt
+  }
+}
+
+// MARK: - Attachment DTO
+
+struct AttachmentDTO: Decodable {
+  let id: Int
+  let fileName: String
+  let fileUrl: String
+  let fileSize: Int?
+  let mimeType: String?
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case fileName
+    case fileUrl
+    case fileSize
+    case mimeType
+  }
+}

--- a/Someverse/Core/Network/DTO/AuthDTO.swift
+++ b/Someverse/Core/Network/DTO/AuthDTO.swift
@@ -1,0 +1,50 @@
+//
+//  AuthDTO.swift
+//  Someverse
+//
+//  Created by 박채현 on 12/10/25.
+//
+
+import Foundation
+
+// MARK: - OAuth Login Response
+
+struct OAuthLoginResponse: Decodable {
+  let userId: Int
+  let email: String?
+  let provider: String
+  let isNewUser: Bool
+  let accessToken: String
+  let refreshToken: String
+
+  enum CodingKeys: String, CodingKey {
+    case userId
+    case email
+    case provider
+    case isNewUser
+    case accessToken
+    case refreshToken
+  }
+}
+
+// MARK: - Token Refresh Response
+
+struct TokenRefreshResponse: Decodable {
+  let accessToken: String
+  let refreshToken: String
+
+  enum CodingKeys: String, CodingKey {
+    case accessToken
+    case refreshToken
+  }
+}
+
+// MARK: - Logout Response
+
+struct LogoutResponse: Decodable {
+  let loggedOut: Bool
+
+  enum CodingKeys: String, CodingKey {
+    case loggedOut
+  }
+}

--- a/Someverse/Core/Network/DTO/ChatDTO.swift
+++ b/Someverse/Core/Network/DTO/ChatDTO.swift
@@ -1,0 +1,206 @@
+//
+//  ChatDTO.swift
+//  Someverse
+//
+//  Created by 박채현 on 12/10/25.
+//
+
+import Foundation
+
+// MARK: - Message Type
+
+enum MessageType: String, Codable {
+  case text = "TEXT"
+  case image = "IMAGE"
+  case system = "SYSTEM"
+}
+
+// MARK: - Chat Room Create Request
+
+struct ChatRoomCreateRequest: Encodable {
+  let receiverId: Int
+  let firstMessage: String?
+
+  enum CodingKeys: String, CodingKey {
+    case receiverId
+    case firstMessage
+  }
+}
+
+// MARK: - Message Send Request
+
+struct MessageSendRequest: Encodable {
+  let content: String
+  let messageType: String
+
+  enum CodingKeys: String, CodingKey {
+    case content
+    case messageType
+  }
+}
+
+// MARK: - Chat Room Response
+
+struct ChatRoomResponse: Decodable {
+  let chatRoomId: Int
+  let participants: [ChatParticipantDTO]
+  let lastMessage: MessageDTO?
+  let createdAt: String
+
+  enum CodingKeys: String, CodingKey {
+    case chatRoomId
+    case participants
+    case lastMessage
+    case createdAt
+  }
+}
+
+// MARK: - Chat Participant DTO
+
+struct ChatParticipantDTO: Decodable {
+  let userId: Int
+  let nickName: String
+  let profileImage: String?
+  let isOnline: Bool?
+
+  enum CodingKeys: String, CodingKey {
+    case userId
+    case nickName
+    case profileImage
+    case isOnline
+  }
+}
+
+// MARK: - Chat Room List Response
+
+struct ChatRoomListResponse: Decodable {
+  let chatRooms: [ChatRoomDTO]
+  let pageInfo: PageInfo?
+
+  enum CodingKeys: String, CodingKey {
+    case chatRooms
+    case pageInfo
+  }
+}
+
+// MARK: - Chat Room DTO
+
+struct ChatRoomDTO: Decodable {
+  let chatRoomId: Int
+  let otherUser: ChatParticipantDTO
+  let lastMessage: LastMessageDTO?
+  let unreadCount: Int
+  let updatedAt: String
+
+  enum CodingKeys: String, CodingKey {
+    case chatRoomId
+    case otherUser
+    case lastMessage
+    case unreadCount
+    case updatedAt
+  }
+}
+
+// MARK: - Last Message DTO
+
+struct LastMessageDTO: Decodable {
+  let messageId: Int
+  let content: String
+  let messageType: String
+  let sentAt: String
+
+  enum CodingKeys: String, CodingKey {
+    case messageId
+    case content
+    case messageType
+    case sentAt
+  }
+}
+
+// MARK: - Message List Response
+
+struct MessageListResponse: Decodable {
+  let messages: [MessageDTO]
+  let pageInfo: PageInfo?
+
+  enum CodingKeys: String, CodingKey {
+    case messages
+    case pageInfo
+  }
+}
+
+// MARK: - Message DTO
+
+struct MessageDTO: Decodable {
+  let messageId: Int
+  let chatRoomId: Int
+  let senderId: Int
+  let senderNickName: String
+  let senderProfileImage: String?
+  let content: String
+  let messageType: String
+  let isRead: Bool
+  let sentAt: String
+
+  enum CodingKeys: String, CodingKey {
+    case messageId
+    case chatRoomId
+    case senderId
+    case senderNickName
+    case senderProfileImage
+    case content
+    case messageType
+    case isRead
+    case sentAt
+  }
+}
+
+// MARK: - Unread Count Response
+
+struct UnreadCountResponse: Decodable {
+  let totalUnreadCount: Int
+  let chatRoomUnreadCounts: [ChatRoomUnreadDTO]?
+
+  enum CodingKeys: String, CodingKey {
+    case totalUnreadCount
+    case chatRoomUnreadCounts
+  }
+}
+
+struct ChatRoomUnreadDTO: Decodable {
+  let chatRoomId: Int
+  let unreadCount: Int
+
+  enum CodingKeys: String, CodingKey {
+    case chatRoomId
+    case unreadCount
+  }
+}
+
+// MARK: - Daily Free Chat Count Response
+
+struct DailyFreeChatCountResponse: Decodable {
+  let userId: Int
+  let remainingFreeChats: Int
+  let maxFreeChats: Int
+  let resetAt: String
+
+  enum CodingKeys: String, CodingKey {
+    case userId
+    case remainingFreeChats
+    case maxFreeChats
+    case resetAt
+  }
+}
+
+// MARK: - Chat Room Exit Response
+
+struct ChatRoomExitResponse: Decodable {
+  let chatRoomId: Int
+  let exitedAt: String
+
+  enum CodingKeys: String, CodingKey {
+    case chatRoomId
+    case exitedAt
+  }
+}

--- a/Someverse/Core/Network/DTO/CommonDTO.swift
+++ b/Someverse/Core/Network/DTO/CommonDTO.swift
@@ -1,0 +1,53 @@
+//
+//  CommonDTO.swift
+//  Someverse
+//
+//  Created by 박채현 on 12/10/25.
+//
+
+import Foundation
+
+// MARK: - API Response Wrapper
+
+struct APIResponse<T: Decodable>: Decodable {
+  let success: Bool
+  let code: String
+  let message: String
+  let data: T?
+}
+
+// MARK: - Empty Response (데이터 없는 응답용)
+
+struct EmptyResponse: Decodable {}
+
+// MARK: - Page Info
+
+struct PageInfo: Decodable {
+  let page: Int
+  let size: Int
+  let totalElements: Int
+  let totalPages: Int
+  let isFirst: Bool
+  let isLast: Bool
+
+  enum CodingKeys: String, CodingKey {
+    case page
+    case size
+    case totalElements
+    case totalPages
+    case isFirst = "first"
+    case isLast = "last"
+  }
+}
+
+// MARK: - Paginated Response
+
+struct PaginatedResponse<T: Decodable>: Decodable {
+  let content: [T]
+  let pageInfo: PageInfo
+
+  enum CodingKeys: String, CodingKey {
+    case content
+    case pageInfo
+  }
+}

--- a/Someverse/Core/Network/DTO/FeedDTO.swift
+++ b/Someverse/Core/Network/DTO/FeedDTO.swift
@@ -1,0 +1,216 @@
+//
+//  FeedDTO.swift
+//  Someverse
+//
+//  Created by 박채현 on 12/10/25.
+//
+
+import Foundation
+
+// MARK: - Feed Type
+
+enum FeedType: String, Codable {
+  case movie = "MOVIE"
+  case music = "MUSIC"
+  case text = "TEXT"
+}
+
+// MARK: - Feed Create Request
+
+struct FeedCreateRequest: Encodable {
+  let feedType: String
+  let movieId: Int?
+  let musicId: Int?
+  let content: String?
+  let imageUrls: [String]?
+
+  enum CodingKeys: String, CodingKey {
+    case feedType
+    case movieId
+    case musicId
+    case content
+    case imageUrls
+  }
+}
+
+// MARK: - Feed Update Request
+
+struct FeedUpdateRequest: Encodable {
+  let content: String?
+  let imageUrls: [String]?
+
+  enum CodingKeys: String, CodingKey {
+    case content
+    case imageUrls
+  }
+}
+
+// MARK: - Feed Create Response
+
+struct FeedCreateResponse: Decodable {
+  let feedId: Int
+  let userId: Int
+  let feedType: String
+  let createdAt: String
+
+  enum CodingKeys: String, CodingKey {
+    case feedId
+    case userId
+    case feedType
+    case createdAt
+  }
+}
+
+// MARK: - Feed List Response
+
+struct FeedListResponse: Decodable {
+  let feeds: [FeedDTO]
+  let pageInfo: PageInfo?
+
+  enum CodingKeys: String, CodingKey {
+    case feeds
+    case pageInfo
+  }
+}
+
+// MARK: - Feed DTO
+
+struct FeedDTO: Decodable {
+  let feedId: Int
+  let userId: Int
+  let userNickName: String
+  let userProfileImage: String?
+  let feedType: String
+  let movie: FeedMovieDTO?
+  let music: FeedMusicDTO?
+  let content: String?
+  let imageUrls: [String]?
+  let likeCount: Int
+  let commentCount: Int
+  let isLiked: Bool
+  let createdAt: String
+  let updatedAt: String
+
+  enum CodingKeys: String, CodingKey {
+    case feedId
+    case userId
+    case userNickName
+    case userProfileImage
+    case feedType
+    case movie
+    case music
+    case content
+    case imageUrls
+    case likeCount
+    case commentCount
+    case isLiked
+    case createdAt
+    case updatedAt
+  }
+}
+
+// MARK: - Feed Movie DTO
+
+struct FeedMovieDTO: Decodable {
+  let movieId: Int
+  let title: String
+  let posterPath: String?
+
+  enum CodingKeys: String, CodingKey {
+    case movieId
+    case title
+    case posterPath
+  }
+}
+
+// MARK: - Feed Music DTO
+
+struct FeedMusicDTO: Decodable {
+  let musicId: Int
+  let title: String
+  let artist: String
+  let albumArtUrl: String?
+
+  enum CodingKeys: String, CodingKey {
+    case musicId
+    case title
+    case artist
+    case albumArtUrl
+  }
+}
+
+// MARK: - Feed Detail Response
+
+struct FeedDetailResponse: Decodable {
+  let feed: FeedDTO
+  let comments: [FeedCommentDTO]?
+
+  enum CodingKeys: String, CodingKey {
+    case feed
+    case comments
+  }
+}
+
+// MARK: - Feed Comment DTO
+
+struct FeedCommentDTO: Decodable {
+  let commentId: Int
+  let userId: Int
+  let userNickName: String
+  let userProfileImage: String?
+  let content: String
+  let createdAt: String
+
+  enum CodingKeys: String, CodingKey {
+    case commentId
+    case userId
+    case userNickName
+    case userProfileImage
+    case content
+    case createdAt
+  }
+}
+
+// MARK: - Feed Like Response
+
+struct FeedLikeResponse: Decodable {
+  let feedId: Int
+  let userId: Int
+  let isLiked: Bool
+  let likeCount: Int
+
+  enum CodingKeys: String, CodingKey {
+    case feedId
+    case userId
+    case isLiked
+    case likeCount
+  }
+}
+
+// MARK: - Comment Create Request
+
+struct CommentCreateRequest: Encodable {
+  let content: String
+
+  enum CodingKeys: String, CodingKey {
+    case content
+  }
+}
+
+// MARK: - Comment Create Response
+
+struct CommentCreateResponse: Decodable {
+  let commentId: Int
+  let feedId: Int
+  let userId: Int
+  let content: String
+  let createdAt: String
+
+  enum CodingKeys: String, CodingKey {
+    case commentId
+    case feedId
+    case userId
+    case content
+    case createdAt
+  }
+}

--- a/Someverse/Core/Network/DTO/FileDTO.swift
+++ b/Someverse/Core/Network/DTO/FileDTO.swift
@@ -1,0 +1,106 @@
+//
+//  FileDTO.swift
+//  Someverse
+//
+//  Created by 박채현 on 12/10/25.
+//
+
+import Foundation
+
+// MARK: - File Upload Response
+
+struct FileUploadResponse: Decodable {
+  let urls: [String]
+
+  enum CodingKeys: String, CodingKey {
+    case urls
+  }
+}
+
+// MARK: - Single File Upload Response
+
+struct SingleFileUploadResponse: Decodable {
+  let url: String
+  let fileName: String?
+  let fileSize: Int?
+  let mimeType: String?
+
+  enum CodingKeys: String, CodingKey {
+    case url
+    case fileName
+    case fileSize
+    case mimeType
+  }
+}
+
+// MARK: - Presigned URL Request
+
+struct PresignedURLRequest: Encodable {
+  let fileName: String
+  let contentType: String
+  let directory: String?
+
+  enum CodingKeys: String, CodingKey {
+    case fileName
+    case contentType
+    case directory
+  }
+}
+
+// MARK: - Presigned URL Response
+
+struct PresignedURLResponse: Decodable {
+  let uploadUrl: String
+  let fileUrl: String
+  let expiresAt: String
+
+  enum CodingKeys: String, CodingKey {
+    case uploadUrl
+    case fileUrl
+    case expiresAt
+  }
+}
+
+// MARK: - Multiple Presigned URL Request
+
+struct MultiplePresignedURLRequest: Encodable {
+  let files: [FileInfoRequest]
+
+  enum CodingKeys: String, CodingKey {
+    case files
+  }
+}
+
+struct FileInfoRequest: Encodable {
+  let fileName: String
+  let contentType: String
+
+  enum CodingKeys: String, CodingKey {
+    case fileName
+    case contentType
+  }
+}
+
+// MARK: - Multiple Presigned URL Response
+
+struct MultiplePresignedURLResponse: Decodable {
+  let urls: [PresignedURLInfo]
+
+  enum CodingKeys: String, CodingKey {
+    case urls
+  }
+}
+
+struct PresignedURLInfo: Decodable {
+  let uploadUrl: String
+  let fileUrl: String
+  let fileName: String
+  let expiresAt: String
+
+  enum CodingKeys: String, CodingKey {
+    case uploadUrl
+    case fileUrl
+    case fileName
+    case expiresAt
+  }
+}

--- a/Someverse/Core/Network/DTO/GenreDTO.swift
+++ b/Someverse/Core/Network/DTO/GenreDTO.swift
@@ -1,0 +1,34 @@
+//
+//  GenreDTO.swift
+//  Someverse
+//
+//  Created by 박채현 on 12/10/25.
+//
+
+import Foundation
+
+// MARK: - Genre List Response
+
+struct GenreListResponse: Decodable {
+  let genres: [GenreDTO]
+
+  enum CodingKeys: String, CodingKey {
+    case genres
+  }
+}
+
+// MARK: - Genre DTO
+
+struct GenreDTO: Decodable {
+  let id: Int
+  let name: String
+  let type: String
+  let externalId: Int?
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case name
+    case type
+    case externalId
+  }
+}

--- a/Someverse/Core/Network/DTO/MatchingDTO.swift
+++ b/Someverse/Core/Network/DTO/MatchingDTO.swift
@@ -1,0 +1,170 @@
+//
+//  MatchingDTO.swift
+//  Someverse
+//
+//  Created by 박채현 on 12/10/25.
+//
+
+import Foundation
+
+// MARK: - Daily Matching Response
+
+struct DailyMatchingResponse: Decodable {
+  let matchingDate: String
+  let users: [MatchingUserDTO]
+  let remainingRefreshCount: Int
+
+  enum CodingKeys: String, CodingKey {
+    case matchingDate
+    case users
+    case remainingRefreshCount
+  }
+}
+
+// MARK: - Matching User DTO
+
+struct MatchingUserDTO: Decodable {
+  let userId: Int
+  let nickName: String
+  let age: Int
+  let gender: String
+  let profileImages: [String]
+  let bio: String?
+  let job: String?
+  let locations: [LocationDTO]
+  let matchingScore: Int
+  let commonGenres: [MatchingGenreDTO]?
+  let commonMovies: [MatchingMovieDTO]?
+
+  enum CodingKeys: String, CodingKey {
+    case userId
+    case nickName
+    case age
+    case gender
+    case profileImages
+    case bio
+    case job
+    case locations
+    case matchingScore
+    case commonGenres
+    case commonMovies
+  }
+}
+
+// MARK: - Matching Genre DTO
+
+struct MatchingGenreDTO: Decodable {
+  let genreId: Int
+  let name: String
+
+  enum CodingKeys: String, CodingKey {
+    case genreId
+    case name
+  }
+}
+
+// MARK: - Matching Movie DTO
+
+struct MatchingMovieDTO: Decodable {
+  let movieId: Int
+  let title: String
+  let posterPath: String?
+
+  enum CodingKeys: String, CodingKey {
+    case movieId
+    case title
+    case posterPath
+  }
+}
+
+// MARK: - Matching History Response
+
+struct MatchingHistoryResponse: Decodable {
+  let history: [MatchingHistoryDTO]
+  let pageInfo: PageInfo?
+
+  enum CodingKeys: String, CodingKey {
+    case history
+    case pageInfo
+  }
+}
+
+// MARK: - Matching History DTO
+
+struct MatchingHistoryDTO: Decodable {
+  let matchingId: Int
+  let matchedUser: MatchingHistoryUserDTO
+  let matchingScore: Int
+  let matchedAt: String
+  let status: String
+
+  enum CodingKeys: String, CodingKey {
+    case matchingId
+    case matchedUser
+    case matchingScore
+    case matchedAt
+    case status
+  }
+}
+
+// MARK: - Matching History User DTO
+
+struct MatchingHistoryUserDTO: Decodable {
+  let userId: Int
+  let nickName: String
+  let age: Int
+  let profileImage: String?
+
+  enum CodingKeys: String, CodingKey {
+    case userId
+    case nickName
+    case age
+    case profileImage
+  }
+}
+
+// MARK: - Like/Pass Request
+
+struct MatchingActionRequest: Encodable {
+  let targetUserId: Int
+  let action: String
+
+  enum CodingKeys: String, CodingKey {
+    case targetUserId
+    case action
+  }
+}
+
+// MARK: - Like/Pass Response
+
+struct MatchingActionResponse: Decodable {
+  let userId: Int
+  let targetUserId: Int
+  let action: String
+  let isMatched: Bool
+  let chatRoomId: Int?
+  let createdAt: String
+
+  enum CodingKeys: String, CodingKey {
+    case userId
+    case targetUserId
+    case action
+    case isMatched
+    case chatRoomId
+    case createdAt
+  }
+}
+
+// MARK: - Refresh Matching Response
+
+struct RefreshMatchingResponse: Decodable {
+  let users: [MatchingUserDTO]
+  let remainingRefreshCount: Int
+  let nextRefreshAt: String?
+
+  enum CodingKeys: String, CodingKey {
+    case users
+    case remainingRefreshCount
+    case nextRefreshAt
+  }
+}

--- a/Someverse/Core/Network/DTO/MovieDTO.swift
+++ b/Someverse/Core/Network/DTO/MovieDTO.swift
@@ -1,0 +1,242 @@
+//
+//  MovieDTO.swift
+//  Someverse
+//
+//  Created by 박채현 on 12/10/25.
+//
+
+import Foundation
+
+// MARK: - Movie DTO
+
+struct MovieDTO: Decodable {
+  let id: Int
+  let tmdbId: Int
+  let title: String
+  let originalTitle: String?
+  let overview: String?
+  let posterPath: String?
+  let backdropPath: String?
+  let releaseDate: String?
+  let runtime: Int?
+  let voteAverage: Double?
+  let voteCount: Int?
+  let popularity: Double?
+  let genres: [GenreDTO]?
+  let adult: Bool?
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case tmdbId
+    case title
+    case originalTitle
+    case overview
+    case posterPath
+    case backdropPath
+    case releaseDate
+    case runtime
+    case voteAverage
+    case voteCount
+    case popularity
+    case genres
+    case adult
+  }
+}
+
+// MARK: - Movie List Response
+
+struct MovieListResponse: Decodable {
+  let movies: [MovieDTO]
+  let pageInfo: PageInfo?
+
+  enum CodingKeys: String, CodingKey {
+    case movies
+    case pageInfo
+  }
+}
+
+// MARK: - Movie Search Response
+
+struct MovieSearchResponse: Decodable {
+  let results: [MovieSearchResultDTO]
+  let totalResults: Int
+  let totalPages: Int
+  let page: Int
+
+  enum CodingKeys: String, CodingKey {
+    case results
+    case totalResults
+    case totalPages
+    case page
+  }
+}
+
+struct MovieSearchResultDTO: Decodable {
+  let id: Int
+  let title: String
+  let originalTitle: String?
+  let overview: String?
+  let posterPath: String?
+  let releaseDate: String?
+  let voteAverage: Double?
+  let popularity: Double?
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case title
+    case originalTitle
+    case overview
+    case posterPath
+    case releaseDate
+    case voteAverage
+    case popularity
+  }
+}
+
+// MARK: - Movie Detail Response
+
+struct MovieDetailResponse: Decodable {
+  let id: Int
+  let tmdbId: Int
+  let title: String
+  let originalTitle: String?
+  let overview: String?
+  let posterPath: String?
+  let backdropPath: String?
+  let releaseDate: String?
+  let runtime: Int?
+  let voteAverage: Double?
+  let voteCount: Int?
+  let popularity: Double?
+  let genres: [GenreDTO]
+  let cast: [CastDTO]?
+  let crew: [CrewDTO]?
+  let videos: [VideoDTO]?
+  let adult: Bool
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case tmdbId
+    case title
+    case originalTitle
+    case overview
+    case posterPath
+    case backdropPath
+    case releaseDate
+    case runtime
+    case voteAverage
+    case voteCount
+    case popularity
+    case genres
+    case cast
+    case crew
+    case videos
+    case adult
+  }
+}
+
+// MARK: - Cast & Crew DTO
+
+struct CastDTO: Decodable {
+  let id: Int
+  let name: String
+  let character: String?
+  let profilePath: String?
+  let order: Int?
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case name
+    case character
+    case profilePath
+    case order
+  }
+}
+
+struct CrewDTO: Decodable {
+  let id: Int
+  let name: String
+  let job: String
+  let department: String?
+  let profilePath: String?
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case name
+    case job
+    case department
+    case profilePath
+  }
+}
+
+// MARK: - Video DTO
+
+struct VideoDTO: Decodable {
+  let id: String
+  let key: String
+  let name: String
+  let site: String
+  let type: String
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case key
+    case name
+    case site
+    case type
+  }
+}
+
+// MARK: - Onboarding Movie Response
+
+struct OnboardingMovieResponse: Decodable {
+  let movies: [OnboardingMovieDTO]
+
+  enum CodingKeys: String, CodingKey {
+    case movies
+  }
+}
+
+struct OnboardingMovieDTO: Decodable {
+  let id: Int
+  let title: String
+  let posterPath: String?
+  let releaseYear: Int?
+  let genreIds: [Int]?
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case title
+    case posterPath
+    case releaseYear
+    case genreIds
+  }
+}
+
+// MARK: - Popular Movies Response
+
+struct PopularMoviesResponse: Decodable {
+  let movies: [MovieDTO]
+  let pageInfo: PageInfo?
+
+  enum CodingKeys: String, CodingKey {
+    case movies
+    case pageInfo
+  }
+}
+
+// MARK: - Movies By Genre Response
+
+struct MoviesByGenreResponse: Decodable {
+  let genreId: Int
+  let genreName: String
+  let movies: [MovieDTO]
+  let pageInfo: PageInfo?
+
+  enum CodingKeys: String, CodingKey {
+    case genreId
+    case genreName
+    case movies
+    case pageInfo
+  }
+}

--- a/Someverse/Core/Network/DTO/NotificationDTO.swift
+++ b/Someverse/Core/Network/DTO/NotificationDTO.swift
@@ -1,0 +1,131 @@
+//
+//  NotificationDTO.swift
+//  Someverse
+//
+//  Created by 박채현 on 12/10/25.
+//
+
+import Foundation
+
+// MARK: - Notification Type
+
+enum NotificationType: String, Codable {
+  case matching = "MATCHING"
+  case chat = "CHAT"
+  case like = "LIKE"
+  case comment = "COMMENT"
+  case system = "SYSTEM"
+  case marketing = "MARKETING"
+}
+
+// MARK: - FCM Token Request
+
+struct FCMTokenRequest: Encodable {
+  let fcmToken: String
+  let deviceType: String
+
+  enum CodingKeys: String, CodingKey {
+    case fcmToken
+    case deviceType
+  }
+}
+
+// MARK: - FCM Token Response
+
+struct FCMTokenResponse: Decodable {
+  let userId: Int
+  let registered: Bool
+  let registeredAt: String
+
+  enum CodingKeys: String, CodingKey {
+    case userId
+    case registered
+    case registeredAt
+  }
+}
+
+// MARK: - Notification List Response
+
+struct NotificationListResponse: Decodable {
+  let notifications: [NotificationDTO]
+  let pageInfo: PageInfo?
+
+  enum CodingKeys: String, CodingKey {
+    case notifications
+    case pageInfo
+  }
+}
+
+// MARK: - Notification DTO
+
+struct NotificationDTO: Decodable {
+  let notificationId: Int
+  let type: String
+  let title: String
+  let body: String
+  let data: NotificationDataDTO?
+  let isRead: Bool
+  let createdAt: String
+
+  enum CodingKeys: String, CodingKey {
+    case notificationId
+    case type
+    case title
+    case body
+    case data
+    case isRead
+    case createdAt
+  }
+}
+
+// MARK: - Notification Data DTO
+
+struct NotificationDataDTO: Decodable {
+  let targetId: Int?
+  let targetType: String?
+  let senderId: Int?
+  let senderNickName: String?
+  let senderProfileImage: String?
+
+  enum CodingKeys: String, CodingKey {
+    case targetId
+    case targetType
+    case senderId
+    case senderNickName
+    case senderProfileImage
+  }
+}
+
+// MARK: - Unread Notification Count Response
+
+struct UnreadNotificationCountResponse: Decodable {
+  let unreadCount: Int
+
+  enum CodingKeys: String, CodingKey {
+    case unreadCount
+  }
+}
+
+// MARK: - Notification Read Response
+
+struct NotificationReadResponse: Decodable {
+  let notificationId: Int
+  let isRead: Bool
+  let readAt: String
+
+  enum CodingKeys: String, CodingKey {
+    case notificationId
+    case isRead
+    case readAt
+  }
+}
+
+// MARK: - Read All Notifications Response
+
+struct ReadAllNotificationsResponse: Decodable {
+  let updatedCount: Int
+
+  enum CodingKeys: String, CodingKey {
+    case updatedCount
+  }
+}

--- a/Someverse/Core/Network/DTO/PointDTO.swift
+++ b/Someverse/Core/Network/DTO/PointDTO.swift
@@ -1,0 +1,151 @@
+//
+//  PointDTO.swift
+//  Someverse
+//
+//  Created by 박채현 on 12/10/25.
+//
+
+import Foundation
+
+// MARK: - Transaction Type
+
+enum PointTransactionType: String, Codable {
+  case charge = "CHARGE"
+  case use = "USE"
+  case reward = "REWARD"
+  case refund = "REFUND"
+}
+
+// MARK: - Point Balance Response
+
+struct PointBalanceResponse: Decodable {
+  let userId: Int
+  let pointBalance: Int
+  let lumiBalance: Int?
+
+  enum CodingKeys: String, CodingKey {
+    case userId
+    case pointBalance
+    case lumiBalance
+  }
+}
+
+// MARK: - Point Transaction List Response
+
+struct PointTransactionListResponse: Decodable {
+  let transactions: [PointTransactionDTO]
+  let pageInfo: PageInfo?
+
+  enum CodingKeys: String, CodingKey {
+    case transactions
+    case pageInfo
+  }
+}
+
+// MARK: - Point Transaction DTO
+
+struct PointTransactionDTO: Decodable {
+  let transactionId: Int
+  let type: String
+  let amount: Int
+  let balanceAfter: Int
+  let reason: String
+  let relatedId: Int?
+  let relatedType: String?
+  let createdAt: String
+
+  enum CodingKeys: String, CodingKey {
+    case transactionId
+    case type
+    case amount
+    case balanceAfter
+    case reason
+    case relatedId
+    case relatedType
+    case createdAt
+  }
+}
+
+// MARK: - Free Chat Available Response
+
+struct FreeChatAvailableResponse: Decodable {
+  let userId: Int
+  let isAvailable: Bool
+  let remainingCount: Int
+  let maxCount: Int
+  let resetAt: String
+
+  enum CodingKeys: String, CodingKey {
+    case userId
+    case isAvailable
+    case remainingCount
+    case maxCount
+    case resetAt
+  }
+}
+
+// MARK: - Point Charge Request
+
+struct PointChargeRequest: Encodable {
+  let amount: Int
+  let paymentMethod: String
+  let receiptId: String?
+
+  enum CodingKeys: String, CodingKey {
+    case amount
+    case paymentMethod
+    case receiptId
+  }
+}
+
+// MARK: - Point Charge Response
+
+struct PointChargeResponse: Decodable {
+  let transactionId: Int
+  let userId: Int
+  let amount: Int
+  let balanceAfter: Int
+  let chargedAt: String
+
+  enum CodingKeys: String, CodingKey {
+    case transactionId
+    case userId
+    case amount
+    case balanceAfter
+    case chargedAt
+  }
+}
+
+// MARK: - Point Use Request
+
+struct PointUseRequest: Encodable {
+  let amount: Int
+  let reason: String
+  let relatedId: Int?
+  let relatedType: String?
+
+  enum CodingKeys: String, CodingKey {
+    case amount
+    case reason
+    case relatedId
+    case relatedType
+  }
+}
+
+// MARK: - Point Use Response
+
+struct PointUseResponse: Decodable {
+  let transactionId: Int
+  let userId: Int
+  let amount: Int
+  let balanceAfter: Int
+  let usedAt: String
+
+  enum CodingKeys: String, CodingKey {
+    case transactionId
+    case userId
+    case amount
+    case balanceAfter
+    case usedAt
+  }
+}

--- a/Someverse/Core/Network/DTO/RegionDTO.swift
+++ b/Someverse/Core/Network/DTO/RegionDTO.swift
@@ -1,0 +1,30 @@
+//
+//  RegionDTO.swift
+//  Someverse
+//
+//  Created by 박채현 on 12/10/25.
+//
+
+import Foundation
+
+// MARK: - Region List Response
+
+struct RegionListResponse: Decodable {
+  let regions: [RegionDTO]
+
+  enum CodingKeys: String, CodingKey {
+    case regions
+  }
+}
+
+// MARK: - Region DTO
+
+struct RegionDTO: Decodable {
+  let city: String
+  let districts: [String]
+
+  enum CodingKeys: String, CodingKey {
+    case city
+    case districts
+  }
+}

--- a/Someverse/Core/Network/DTO/TermsDTO.swift
+++ b/Someverse/Core/Network/DTO/TermsDTO.swift
@@ -1,0 +1,90 @@
+//
+//  TermsDTO.swift
+//  Someverse
+//
+//  Created by 박채현 on 12/10/25.
+//
+
+import Foundation
+
+// MARK: - Terms List Response
+
+struct TermsListResponse: Decodable {
+  let terms: [TermsDTO]
+
+  enum CodingKeys: String, CodingKey {
+    case terms
+  }
+}
+
+// MARK: - Terms DTO
+
+struct TermsDTO: Decodable {
+  let id: Int
+  let title: String
+  let content: String
+  let isRequired: Bool
+  let version: String
+  let effectiveDate: String
+  let createdAt: String
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case title
+    case content
+    case isRequired
+    case version
+    case effectiveDate
+    case createdAt
+  }
+}
+
+// MARK: - Terms Detail Response
+
+struct TermsDetailResponse: Decodable {
+  let id: Int
+  let title: String
+  let content: String
+  let isRequired: Bool
+  let version: String
+  let effectiveDate: String
+  let createdAt: String
+  let updatedAt: String
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case title
+    case content
+    case isRequired
+    case version
+    case effectiveDate
+    case createdAt
+    case updatedAt
+  }
+}
+
+// MARK: - User Terms Agreement Response
+
+struct UserTermsAgreementResponse: Decodable {
+  let userId: Int
+  let agreements: [UserTermsAgreementDTO]
+
+  enum CodingKeys: String, CodingKey {
+    case userId
+    case agreements
+  }
+}
+
+struct UserTermsAgreementDTO: Decodable {
+  let termsId: Int
+  let termsTitle: String
+  let agreed: Bool
+  let agreedAt: String?
+
+  enum CodingKeys: String, CodingKey {
+    case termsId
+    case termsTitle
+    case agreed
+    case agreedAt
+  }
+}

--- a/Someverse/Core/Network/DTO/UserDTO.swift
+++ b/Someverse/Core/Network/DTO/UserDTO.swift
@@ -1,0 +1,512 @@
+//
+//  UserDTO.swift
+//  Someverse
+//
+//  Created by 박채현 on 12/10/25.
+//
+
+import Foundation
+
+// MARK: - Common Models
+
+struct LocationDTO: Codable {
+  let city: String
+  let district: String
+
+  enum CodingKeys: String, CodingKey {
+    case city
+    case district
+  }
+}
+
+// MARK: - User Me Response
+
+struct UserMeResponse: Decodable {
+  let userId: Int
+  let email: String?
+  let provider: String
+  let isOnboardingCompleted: Bool
+  let createdAt: String
+
+  enum CodingKeys: String, CodingKey {
+    case userId
+    case email
+    case provider
+    case isOnboardingCompleted
+    case createdAt
+  }
+}
+
+// MARK: - Onboarding Status Response
+
+struct OnboardingStatusResponse: Decodable {
+  let userId: Int
+  let currentStep: String
+  let completedSteps: [String]
+  let isCompleted: Bool
+
+  enum CodingKeys: String, CodingKey {
+    case userId
+    case currentStep
+    case completedSteps
+    case isCompleted
+  }
+}
+
+// MARK: - Terms Agree
+
+struct TermsAgreeRequest: Encodable {
+  let termsAgreements: [TermsAgreementItem]
+
+  enum CodingKeys: String, CodingKey {
+    case termsAgreements
+  }
+}
+
+struct TermsAgreementItem: Codable {
+  let termsId: Int
+  let agreed: Bool
+
+  enum CodingKeys: String, CodingKey {
+    case termsId
+    case agreed
+  }
+}
+
+struct TermsAgreeResponse: Decodable {
+  let userId: Int
+  let agreedTerms: [Int]
+  let agreedAt: String
+
+  enum CodingKeys: String, CodingKey {
+    case userId
+    case agreedTerms
+    case agreedAt
+  }
+}
+
+// MARK: - Basic Info
+
+struct BasicInfoRequest: Encodable {
+  let nickName: String
+  let realName: String
+  let gender: String
+  let birthDate: String
+  let phone: String
+  let email: String?
+
+  enum CodingKeys: String, CodingKey {
+    case nickName
+    case realName
+    case gender
+    case birthDate
+    case phone
+    case email
+  }
+}
+
+struct BasicInfoResponse: Decodable {
+  let userId: Int
+  let nickName: String
+  let realName: String
+  let gender: String
+  let birthDate: String
+  let age: Int
+  let phone: String
+  let email: String?
+
+  enum CodingKeys: String, CodingKey {
+    case userId
+    case nickName
+    case realName
+    case gender
+    case birthDate
+    case age
+    case phone
+    case email
+  }
+}
+
+// MARK: - Location
+
+struct LocationRequest: Encodable {
+  let locations: [LocationDTO]
+
+  enum CodingKeys: String, CodingKey {
+    case locations
+  }
+}
+
+struct LocationResponse: Decodable {
+  let userId: Int
+  let locations: [LocationDTO]
+
+  enum CodingKeys: String, CodingKey {
+    case userId
+    case locations
+  }
+}
+
+// MARK: - Profile Images
+
+struct ProfileImagesRequest: Encodable {
+  let imageUrls: [String]
+
+  enum CodingKeys: String, CodingKey {
+    case imageUrls
+  }
+}
+
+struct ProfileImagesResponse: Decodable {
+  let userId: Int
+  let profileImages: [ProfileImageDTO]
+
+  enum CodingKeys: String, CodingKey {
+    case userId
+    case profileImages
+  }
+}
+
+struct ProfileImageDTO: Decodable {
+  let imageId: Int
+  let imageUrl: String
+  let orderIndex: Int
+  let isPrimary: Bool
+
+  enum CodingKeys: String, CodingKey {
+    case imageId
+    case imageUrl
+    case orderIndex
+    case isPrimary
+  }
+}
+
+// MARK: - Genre Select
+
+struct GenreSelectRequest: Encodable {
+  let genreIds: [Int]
+
+  enum CodingKeys: String, CodingKey {
+    case genreIds
+  }
+}
+
+struct GenreSelectResponse: Decodable {
+  let userId: Int
+  let selectedGenres: [SelectedGenreDTO]
+
+  enum CodingKeys: String, CodingKey {
+    case userId
+    case selectedGenres
+  }
+}
+
+struct SelectedGenreDTO: Decodable {
+  let genreId: Int
+  let name: String
+
+  enum CodingKeys: String, CodingKey {
+    case genreId
+    case name
+  }
+}
+
+// MARK: - Movie Select
+
+struct MovieSelectRequest: Encodable {
+  let movieIds: [Int]
+
+  enum CodingKeys: String, CodingKey {
+    case movieIds
+  }
+}
+
+struct MovieSelectResponse: Decodable {
+  let userId: Int
+  let selectedMovies: [SelectedMovieDTO]
+
+  enum CodingKeys: String, CodingKey {
+    case userId
+    case selectedMovies
+  }
+}
+
+struct SelectedMovieDTO: Decodable {
+  let movieId: Int
+  let title: String
+  let posterPath: String?
+
+  enum CodingKeys: String, CodingKey {
+    case movieId
+    case title
+    case posterPath
+  }
+}
+
+// MARK: - Onboarding Complete
+
+struct OnboardingCompleteResponse: Decodable {
+  let userId: Int
+  let isCompleted: Bool
+  let completedAt: String
+
+  enum CodingKeys: String, CodingKey {
+    case userId
+    case isCompleted
+    case completedAt
+  }
+}
+
+// MARK: - User Profile Response
+
+struct UserProfileResponse: Decodable {
+  let userId: Int
+  let nickName: String
+  let realName: String?
+  let gender: String
+  let birthDate: String
+  let age: Int
+  let bio: String?
+  let job: String?
+  let phone: String?
+  let email: String?
+  let locations: [LocationDTO]
+  let profileImages: [ProfileImageDTO]
+  let selectedGenres: [SelectedGenreDTO]
+  let selectedMovies: [SelectedMovieDTO]
+  let isOnboardingCompleted: Bool
+  let createdAt: String
+  let updatedAt: String
+
+  enum CodingKeys: String, CodingKey {
+    case userId
+    case nickName
+    case realName
+    case gender
+    case birthDate
+    case age
+    case bio
+    case job
+    case phone
+    case email
+    case locations
+    case profileImages
+    case selectedGenres
+    case selectedMovies
+    case isOnboardingCompleted
+    case createdAt
+    case updatedAt
+  }
+}
+
+// MARK: - Nickname Check
+
+struct NicknameCheckResponse: Decodable {
+  let nickname: String
+  let isAvailable: Bool
+  let reason: String?
+
+  enum CodingKeys: String, CodingKey {
+    case nickname
+    case isAvailable
+    case reason
+  }
+}
+
+// MARK: - Profile Update Requests
+
+struct BioUpdateRequest: Encodable {
+  let bio: String
+
+  enum CodingKeys: String, CodingKey {
+    case bio
+  }
+}
+
+struct JobUpdateRequest: Encodable {
+  let job: String
+
+  enum CodingKeys: String, CodingKey {
+    case job
+  }
+}
+
+struct PhoneUpdateRequest: Encodable {
+  let phone: String
+
+  enum CodingKeys: String, CodingKey {
+    case phone
+  }
+}
+
+struct NicknameUpdateRequest: Encodable {
+  let nickName: String
+
+  enum CodingKeys: String, CodingKey {
+    case nickName
+  }
+}
+
+// MARK: - Matching Filter
+
+struct MatchingFilterRequest: Encodable {
+  let minAge: Int
+  let maxAge: Int
+  let genderPreference: String
+  let maxDistance: Int?
+  let preferredGenreIds: [Int]?
+
+  enum CodingKeys: String, CodingKey {
+    case minAge
+    case maxAge
+    case genderPreference
+    case maxDistance
+    case preferredGenreIds
+  }
+}
+
+struct MatchingFilterResponse: Decodable {
+  let userId: Int
+  let minAge: Int
+  let maxAge: Int
+  let genderPreference: String
+  let maxDistance: Int?
+  let preferredGenreIds: [Int]?
+  let updatedAt: String
+
+  enum CodingKeys: String, CodingKey {
+    case userId
+    case minAge
+    case maxAge
+    case genderPreference
+    case maxDistance
+    case preferredGenreIds
+    case updatedAt
+  }
+}
+
+// MARK: - Theme Preferences
+
+struct ThemePreferencesRequest: Encodable {
+  let isDarkMode: Bool
+  let fontSize: String
+  let language: String
+
+  enum CodingKeys: String, CodingKey {
+    case isDarkMode
+    case fontSize
+    case language
+  }
+}
+
+struct ThemePreferencesResponse: Decodable {
+  let userId: Int
+  let isDarkMode: Bool
+  let fontSize: String
+  let language: String
+  let updatedAt: String
+
+  enum CodingKeys: String, CodingKey {
+    case userId
+    case isDarkMode
+    case fontSize
+    case language
+    case updatedAt
+  }
+}
+
+// MARK: - Notification Settings
+
+struct NotificationSettingsRequest: Encodable {
+  let pushEnabled: Bool
+  let matchingNotification: Bool
+  let chatNotification: Bool
+  let marketingNotification: Bool
+
+  enum CodingKeys: String, CodingKey {
+    case pushEnabled
+    case matchingNotification
+    case chatNotification
+    case marketingNotification
+  }
+}
+
+struct NotificationSettingsResponse: Decodable {
+  let userId: Int
+  let pushEnabled: Bool
+  let matchingNotification: Bool
+  let chatNotification: Bool
+  let marketingNotification: Bool
+  let updatedAt: String
+
+  enum CodingKeys: String, CodingKey {
+    case userId
+    case pushEnabled
+    case matchingNotification
+    case chatNotification
+    case marketingNotification
+    case updatedAt
+  }
+}
+
+// MARK: - Account Deletion
+
+struct AccountDeletionResponse: Decodable {
+  let userId: Int
+  let deletedAt: String
+  let message: String
+
+  enum CodingKeys: String, CodingKey {
+    case userId
+    case deletedAt
+    case message
+  }
+}
+
+// MARK: - Legacy DTOs (Router 호환용)
+
+struct SignUpRequestDTO: Encodable {
+  let nickName: String
+  let realName: String
+  let gender: String
+  let birthDate: String
+  let phone: String
+  let email: String?
+  let locations: [LocationDTO]
+  let genreIds: [Int]
+  let movieIds: [Int]
+  let imageUrls: [String]?
+
+  enum CodingKeys: String, CodingKey {
+    case nickName
+    case realName
+    case gender
+    case birthDate
+    case phone
+    case email
+    case locations
+    case genreIds
+    case movieIds
+    case imageUrls
+  }
+}
+
+struct ProfileUpdateRequestDTO: Encodable {
+  let nickName: String?
+  let bio: String?
+  let job: String?
+  let locations: [LocationDTO]?
+  let genreIds: [Int]?
+  let movieIds: [Int]?
+  let imageUrls: [String]?
+
+  enum CodingKeys: String, CodingKey {
+    case nickName
+    case bio
+    case job
+    case locations
+    case genreIds
+    case movieIds
+    case imageUrls
+  }
+}

--- a/Someverse/Core/Network/Error/NetworkError.swift
+++ b/Someverse/Core/Network/Error/NetworkError.swift
@@ -1,0 +1,127 @@
+//
+//  NetworkError.swift
+//  Someverse
+//
+//  Created by 박채현 on 12/10/25.
+//
+
+import Foundation
+
+enum NetworkError: Error, Equatable {
+  
+  // MARK: - Network Basic Errors
+  
+  case invalidURL
+  case requestFailed
+  case invalidResponse
+  case decodingFailed
+  case encodingFailed
+  case emptyData
+  case unknownError
+  case customError(String)
+  
+  // MARK: - HTTP Status Code Errors
+  
+  case badRequest              // 400
+  case unauthorized            // 401
+  case forbidden               // 403
+  case notFound                // 404
+  case conflict                // 409
+  case accessTokenExpired      // 419
+  case refreshTokenExpired     // 418
+  case tooManyRequests         // 429
+  case serverError             // 500+
+  case invalidStatusCode(Int)
+  
+  // MARK: - Business Logic Errors
+  
+  case duplicateNickname
+  case invalidNickname
+  case registrationFailed
+  case loginFailed
+  
+  // MARK: - Equatable
+  
+  static func == (lhs: NetworkError, rhs: NetworkError) -> Bool {
+    switch (lhs, rhs) {
+    case (.invalidURL, .invalidURL),
+      (.requestFailed, .requestFailed),
+      (.invalidResponse, .invalidResponse),
+      (.decodingFailed, .decodingFailed),
+      (.encodingFailed, .encodingFailed),
+      (.emptyData, .emptyData),
+      (.unknownError, .unknownError),
+      (.badRequest, .badRequest),
+      (.unauthorized, .unauthorized),
+      (.forbidden, .forbidden),
+      (.notFound, .notFound),
+      (.conflict, .conflict),
+      (.accessTokenExpired, .accessTokenExpired),
+      (.refreshTokenExpired, .refreshTokenExpired),
+      (.tooManyRequests, .tooManyRequests),
+      (.serverError, .serverError),
+      (.duplicateNickname, .duplicateNickname),
+      (.invalidNickname, .invalidNickname),
+      (.registrationFailed, .registrationFailed),
+      (.loginFailed, .loginFailed):
+      return true
+    case (.customError(let lhsMsg), .customError(let rhsMsg)):
+      return lhsMsg == rhsMsg
+    case (.invalidStatusCode(let lhsCode), .invalidStatusCode(let rhsCode)):
+      return lhsCode == rhsCode
+    default:
+      return false
+    }
+  }
+  
+  // MARK: - Error Message
+  
+  var errorMessage: String {
+    switch self {
+    case .invalidURL:
+      return "유효하지 않은 URL입니다."
+    case .requestFailed:
+      return "요청에 실패했습니다."
+    case .invalidResponse:
+      return "유효하지 않은 응답입니다."
+    case .decodingFailed:
+      return "데이터 디코딩에 실패했습니다."
+    case .encodingFailed:
+      return "데이터 인코딩에 실패했습니다."
+    case .emptyData:
+      return "데이터가 비어있습니다."
+    case .unknownError:
+      return "알 수 없는 오류가 발생했습니다."
+    case .customError(let message):
+      return message
+    case .badRequest:
+      return "잘못된 요청입니다."
+    case .unauthorized:
+      return "인증이 필요합니다."
+    case .forbidden:
+      return "접근 권한이 없습니다."
+    case .notFound:
+      return "요청한 리소스를 찾을 수 없습니다."
+    case .conflict:
+      return "충돌이 발생했습니다."
+    case .accessTokenExpired:
+      return "액세스 토큰이 만료되었습니다."
+    case .refreshTokenExpired:
+      return "세션이 만료되었습니다. 다시 로그인해주세요."
+    case .tooManyRequests:
+      return "요청이 너무 많습니다. 잠시 후 다시 시도해주세요."
+    case .serverError:
+      return "서버 오류가 발생했습니다."
+    case .invalidStatusCode(let code):
+      return "서버 오류: \(code)"
+    case .duplicateNickname:
+      return "이미 사용 중인 닉네임입니다."
+    case .invalidNickname:
+      return "사용할 수 없는 닉네임입니다."
+    case .registrationFailed:
+      return "회원가입에 실패했습니다."
+    case .loginFailed:
+      return "로그인에 실패했습니다."
+    }
+  }
+}

--- a/Someverse/Core/Network/Manager/AppleLoginManager.swift
+++ b/Someverse/Core/Network/Manager/AppleLoginManager.swift
@@ -1,0 +1,197 @@
+//
+//  AppleLoginManager.swift
+//  Someverse
+//
+//  Created by 박채현 on 12/10/25.
+//
+
+import Foundation
+import AuthenticationServices
+
+@MainActor
+final class AppleLoginManager: NSObject {
+  static let shared = AppleLoginManager()
+  
+  private let networkManager = NetworkManager.shared
+  private let tokenManager = TokenManager.shared
+  
+  private var continuation: CheckedContinuation<AppleAuthResult, Error>?
+  
+  private override init() {
+    super.init()
+  }
+  
+  // MARK: - Apple Login Flow
+  
+  /// Apple 로그인 수행
+  /// - Returns: Apple ID Token 및 닉네임
+  func handleAppleLogin() async throws -> AppleAuthResult {
+    return try await withCheckedThrowingContinuation { continuation in
+      self.continuation = continuation
+      
+      let provider = ASAuthorizationAppleIDProvider()
+      let request = provider.createRequest()
+      request.requestedScopes = [.fullName, .email]
+      
+      let controller = ASAuthorizationController(authorizationRequests: [request])
+      controller.delegate = self
+      controller.presentationContextProvider = self
+      controller.performRequests()
+    }
+  }
+  
+  // MARK: - Server Authentication
+  
+  /// Apple ID Token으로 서버 인증
+  /// - Parameters:
+  ///   - idToken: Apple에서 받은 ID Token
+  ///   - nickname: 사용자 이름 (첫 로그인 시에만 제공)
+  /// - Returns: 로그인 응답 (서버 토큰 포함)
+  func completeLogin(idToken: String, nickname: String?) async throws -> OAuthLoginResponse {
+    let deviceToken = await getDeviceToken()
+
+    let router = AuthRouter.appleLogin(
+      idToken: idToken,
+      deviceToken: deviceToken,
+      nickname: nickname
+    )
+    let response = try await networkManager.request(router, type: OAuthLoginResponse.self)
+
+    // 토큰 저장
+    tokenManager.saveTokens(
+      accessToken: response.accessToken,
+      refreshToken: response.refreshToken
+    )
+    tokenManager.saveUserInfo(userId: String(response.userId))
+    
+#if DEBUG
+    print("AppleLoginManager: 서버 인증 완료 - userId: \(response.userId)")
+#endif
+    
+    return response
+  }
+  
+  // MARK: - Device Token
+  
+  private func getDeviceToken() async -> String {
+    // TODO: FCM 또는 APNs 토큰 반환
+    return ""
+  }
+}
+
+// MARK: - ASAuthorizationControllerDelegate
+
+extension AppleLoginManager: ASAuthorizationControllerDelegate {
+  
+  nonisolated func authorizationController(
+    controller: ASAuthorizationController,
+    didCompleteWithAuthorization authorization: ASAuthorization
+  ) {
+    Task { @MainActor in
+      guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential,
+            let identityToken = credential.identityToken,
+            let idTokenString = String(data: identityToken, encoding: .utf8) else {
+        continuation?.resume(throwing: AppleLoginError.tokenNotFound)
+        continuation = nil
+        return
+      }
+      
+      // 닉네임 추출 (첫 로그인 시에만 제공)
+      var nickname: String?
+      if let fullName = credential.fullName {
+        let givenName = fullName.givenName ?? ""
+        let familyName = fullName.familyName ?? ""
+        let name = "\(familyName)\(givenName)".trimmingCharacters(in: .whitespaces)
+        if !name.isEmpty {
+          nickname = name
+        }
+      }
+      
+      let result = AppleAuthResult(idToken: idTokenString, nickname: nickname)
+      continuation?.resume(returning: result)
+      continuation = nil
+    }
+  }
+  
+  nonisolated func authorizationController(
+    controller: ASAuthorizationController,
+    didCompleteWithError error: Error
+  ) {
+    Task { @MainActor in
+      if let authError = error as? ASAuthorizationError {
+        switch authError.code {
+        case .canceled:
+          continuation?.resume(throwing: AppleLoginError.userCanceled)
+        case .failed:
+          continuation?.resume(throwing: AppleLoginError.authorizationFailed)
+        case .invalidResponse:
+          continuation?.resume(throwing: AppleLoginError.invalidResponse)
+        case .notHandled:
+          continuation?.resume(throwing: AppleLoginError.notHandled)
+        case .unknown:
+          continuation?.resume(throwing: AppleLoginError.unknown)
+        @unknown default:
+          continuation?.resume(throwing: AppleLoginError.unknown)
+        }
+      } else {
+        continuation?.resume(throwing: AppleLoginError.loginFailed(error))
+      }
+      continuation = nil
+    }
+  }
+}
+
+// MARK: - ASAuthorizationControllerPresentationContextProviding
+
+extension AppleLoginManager: ASAuthorizationControllerPresentationContextProviding {
+  
+  nonisolated func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+    // 현재 활성 윈도우 반환
+    guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+          let window = scene.windows.first else {
+      return UIWindow()
+    }
+    return window
+  }
+}
+
+// MARK: - Apple Auth Result
+
+struct AppleAuthResult {
+  let idToken: String
+  let nickname: String?
+}
+
+// MARK: - Apple Login Error
+
+enum AppleLoginError: Error {
+  case tokenNotFound
+  case userCanceled
+  case authorizationFailed
+  case invalidResponse
+  case notHandled
+  case unknown
+  case loginFailed(Error)
+  case serverAuthFailed
+  
+  var errorMessage: String {
+    switch self {
+    case .tokenNotFound:
+      return "Apple ID 토큰을 가져올 수 없습니다."
+    case .userCanceled:
+      return "로그인이 취소되었습니다."
+    case .authorizationFailed:
+      return "인증에 실패했습니다."
+    case .invalidResponse:
+      return "유효하지 않은 응답입니다."
+    case .notHandled:
+      return "처리되지 않은 요청입니다."
+    case .unknown:
+      return "알 수 없는 오류가 발생했습니다."
+    case .loginFailed(let error):
+      return "Apple 로그인 실패: \(error.localizedDescription)"
+    case .serverAuthFailed:
+      return "서버 인증에 실패했습니다."
+    }
+  }
+}

--- a/Someverse/Core/Network/Manager/KakaoLoginManager.swift
+++ b/Someverse/Core/Network/Manager/KakaoLoginManager.swift
@@ -1,0 +1,118 @@
+//
+//  KakaoLoginManager.swift
+//  Someverse
+//
+//  Created by 박채현 on 12/10/25.
+//
+
+import Foundation
+// import KakaoSDKUser  // 카카오 SDK 설치 후 주석 해제
+// import KakaoSDKAuth
+
+final class KakaoLoginManager {
+  static let shared = KakaoLoginManager()
+  
+  private let networkManager = NetworkManager.shared
+  private let tokenManager = TokenManager.shared
+  
+  private init() {}
+  
+  // MARK: - Kakao Login Flow
+  
+  /// 카카오 로그인 수행 (SDK 연동)
+  /// - Returns: 카카오 OAuth 토큰
+  func handleKakaoLogin() async throws -> String {
+    // TODO: 카카오 SDK 설치 후 구현
+    // 현재는 placeholder
+#if DEBUG
+    print("KakaoLoginManager: 카카오 로그인 시도")
+#endif
+    
+    // 실제 구현 시:
+    // if UserApi.isKakaoTalkLoginAvailable() {
+    //     return try await loginWithKakaoTalk()
+    // } else {
+    //     return try await loginWithKakaoAccount()
+    // }
+    
+    throw KakaoLoginError.sdkNotConfigured
+  }
+  
+  /// 카카오톡 앱으로 로그인
+  private func loginWithKakaoTalk() async throws -> String {
+    // TODO: 카카오 SDK 설치 후 구현
+    // return try await withCheckedThrowingContinuation { continuation in
+    //     UserApi.shared.loginWithKakaoTalk { oauthToken, error in
+    //         if let error = error {
+    //             continuation.resume(throwing: KakaoLoginError.loginFailed(error))
+    //         } else if let token = oauthToken?.accessToken {
+    //             continuation.resume(returning: token)
+    //         } else {
+    //             continuation.resume(throwing: KakaoLoginError.tokenNotFound)
+    //         }
+    //     }
+    // }
+    throw KakaoLoginError.sdkNotConfigured
+  }
+  
+  /// 카카오 계정으로 로그인 (웹뷰)
+  private func loginWithKakaoAccount() async throws -> String {
+    // TODO: 카카오 SDK 설치 후 구현
+    throw KakaoLoginError.sdkNotConfigured
+  }
+  
+  // MARK: - Server Authentication
+
+  /// 카카오 OAuth 토큰으로 서버 인증
+  /// - Parameter oauthToken: 카카오에서 받은 OAuth 토큰
+  /// - Returns: 로그인 응답 (서버 토큰 포함)
+  func completeLogin(oauthToken: String) async throws -> OAuthLoginResponse {
+    let deviceToken = await getDeviceToken()
+
+    let router = AuthRouter.kakaoLogin(oauthToken: oauthToken, deviceToken: deviceToken)
+    let response = try await networkManager.request(router, type: OAuthLoginResponse.self)
+
+    // 토큰 저장
+    tokenManager.saveTokens(
+      accessToken: response.accessToken,
+      refreshToken: response.refreshToken
+    )
+    tokenManager.saveUserInfo(userId: String(response.userId))
+    
+#if DEBUG
+    print("KakaoLoginManager: 서버 인증 완료 - userId: \(response.userId)")
+#endif
+    
+    return response
+  }
+  
+  // MARK: - Device Token
+  
+  private func getDeviceToken() async -> String {
+    // TODO: FCM 또는 APNs 토큰 반환
+    // 현재는 빈 문자열 반환
+    return ""
+  }
+}
+
+// MARK: - Kakao Login Error
+
+enum KakaoLoginError: Error {
+  case sdkNotConfigured
+  case loginFailed(Error)
+  case tokenNotFound
+  case serverAuthFailed
+  
+  var errorMessage: String {
+    switch self {
+    case .sdkNotConfigured:
+      return "카카오 SDK가 설정되지 않았습니다."
+    case .loginFailed(let error):
+      return "카카오 로그인 실패: \(error.localizedDescription)"
+    case .tokenNotFound:
+      return "카카오 토큰을 가져올 수 없습니다."
+    case .serverAuthFailed:
+      return "서버 인증에 실패했습니다."
+    }
+  }
+}

--- a/Someverse/Core/Network/Manager/NetworkManager.swift
+++ b/Someverse/Core/Network/Manager/NetworkManager.swift
@@ -1,0 +1,252 @@
+//
+//  NetworkManager.swift
+//  Someverse
+//
+//  Created by 박채현 on 12/10/25.
+//
+
+import Foundation
+
+final class NetworkManager {
+  static let shared = NetworkManager()
+  
+  private let session: URLSession
+  private let middleware: NetworkMiddleware
+  private let tokenManager: TokenManager
+  private var isRefreshing = false
+  
+  private init(
+    session: URLSession = .shared,
+    middleware: NetworkMiddleware = NetworkMiddleware(),
+    tokenManager: TokenManager = .shared
+  ) {
+    self.session = session
+    self.middleware = middleware
+    self.tokenManager = tokenManager
+  }
+  
+  // MARK: - Generic Request
+  
+  func request<T: Decodable>(_ router: APIRouter, type: T.Type) async throws -> T {
+    var urlRequest = try router.asURLRequest()
+    middleware.prepare(request: &urlRequest, authorizationType: router.authorizationType)
+    
+#if DEBUG
+    logRequest(urlRequest)
+#endif
+    
+    do {
+      let (data, response) = try await session.data(for: urlRequest)
+      
+#if DEBUG
+      logResponse(data: data, response: response)
+#endif
+      
+      let processedData = try middleware.handleResponse(data: data, response: response)
+      
+      let decoder = JSONDecoder()
+      decoder.keyDecodingStrategy = .convertFromSnakeCase
+      return try decoder.decode(T.self, from: processedData)
+      
+    } catch let error as NetworkError {
+      // 토큰 만료 시 자동 갱신
+      if error == .accessTokenExpired || error == .unauthorized {
+        return try await handleTokenRefresh(router: router, type: type)
+      }
+      throw error
+    } catch is DecodingError {
+      throw NetworkError.decodingFailed
+    } catch {
+      throw NetworkError.requestFailed
+    }
+  }
+  
+  // MARK: - Request without Response Body
+  
+  func requestWithoutResponse(_ router: APIRouter) async throws {
+    var urlRequest = try router.asURLRequest()
+    middleware.prepare(request: &urlRequest, authorizationType: router.authorizationType)
+    
+#if DEBUG
+    logRequest(urlRequest)
+#endif
+    
+    do {
+      let (data, response) = try await session.data(for: urlRequest)
+      
+#if DEBUG
+      logResponse(data: data, response: response)
+#endif
+      
+      _ = try middleware.handleResponse(data: data, response: response)
+      
+    } catch let error as NetworkError {
+      if error == .accessTokenExpired || error == .unauthorized {
+        try await handleTokenRefreshWithoutResponse(router: router)
+        return
+      }
+      throw error
+    } catch {
+      throw NetworkError.requestFailed
+    }
+  }
+  
+  // MARK: - Image Upload (Multipart)
+  
+  func uploadImage(_ router: APIRouter, imageData: Data, fieldName: String = "image") async throws -> Data {
+    var urlRequest = try router.asURLRequest()
+    middleware.prepare(request: &urlRequest, authorizationType: router.authorizationType)
+    
+    let boundary = "Boundary-\(UUID().uuidString)"
+    urlRequest.setValue(
+      "multipart/form-data; boundary=\(boundary)",
+      forHTTPHeaderField: APIConstants.Header.contentType
+    )
+    
+    var body = Data()
+    
+    // 이미지 데이터 추가
+    body.append("--\(boundary)\r\n".data(using: .utf8)!)
+    body.append("Content-Disposition: form-data; name=\"\(fieldName)\"; filename=\"image.jpg\"\r\n".data(using: .utf8)!)
+    body.append("Content-Type: image/jpeg\r\n\r\n".data(using: .utf8)!)
+    body.append(imageData)
+    body.append("\r\n--\(boundary)--\r\n".data(using: .utf8)!)
+    
+    urlRequest.httpBody = body
+    
+#if DEBUG
+    print("NetworkManager: 이미지 업로드 시작 - 크기: \(imageData.count) bytes")
+#endif
+    
+    let (data, response) = try await session.data(for: urlRequest)
+    return try middleware.handleResponse(data: data, response: response)
+  }
+  
+  // MARK: - Multiple Images Upload
+  
+  func uploadMultipleImages(_ router: APIRouter, images: [Data], fieldName: String = "images") async throws -> Data {
+    var urlRequest = try router.asURLRequest()
+    middleware.prepare(request: &urlRequest, authorizationType: router.authorizationType)
+    
+    let boundary = "Boundary-\(UUID().uuidString)"
+    urlRequest.setValue(
+      "multipart/form-data; boundary=\(boundary)",
+      forHTTPHeaderField: APIConstants.Header.contentType
+    )
+    
+    var body = Data()
+    
+    for (index, imageData) in images.enumerated() {
+      body.append("--\(boundary)\r\n".data(using: .utf8)!)
+      body.append("Content-Disposition: form-data; name=\"\(fieldName)\"; filename=\"image\(index).jpg\"\r\n".data(using: .utf8)!)
+      body.append("Content-Type: image/jpeg\r\n\r\n".data(using: .utf8)!)
+      body.append(imageData)
+      body.append("\r\n".data(using: .utf8)!)
+    }
+    
+    body.append("--\(boundary)--\r\n".data(using: .utf8)!)
+    urlRequest.httpBody = body
+    
+#if DEBUG
+    print("NetworkManager: 다중 이미지 업로드 시작 - 개수: \(images.count)")
+#endif
+    
+    let (data, response) = try await session.data(for: urlRequest)
+    return try middleware.handleResponse(data: data, response: response)
+  }
+  
+  // MARK: - Token Refresh
+  
+  private func handleTokenRefresh<T: Decodable>(router: APIRouter, type: T.Type) async throws -> T {
+    guard !isRefreshing else {
+      throw NetworkError.refreshTokenExpired
+    }
+    
+    isRefreshing = true
+    defer { isRefreshing = false }
+    
+    guard tokenManager.refreshToken != nil else {
+      tokenManager.clearAll()
+      throw NetworkError.refreshTokenExpired
+    }
+    
+#if DEBUG
+    print("NetworkManager: 토큰 갱신 시작")
+#endif
+    
+    // 토큰 갱신 요청
+    let refreshRouter = AuthRouter.refreshToken
+    let tokenResponse = try await request(refreshRouter, type: TokenResponse.self)
+    
+    // 새 토큰 저장
+    tokenManager.saveTokens(
+      accessToken: tokenResponse.accessToken,
+      refreshToken: tokenResponse.refreshToken
+    )
+    
+#if DEBUG
+    print("NetworkManager: 토큰 갱신 완료")
+#endif
+    
+    // 원래 요청 재시도
+    return try await request(router, type: type)
+  }
+  
+  private func handleTokenRefreshWithoutResponse(router: APIRouter) async throws {
+    guard !isRefreshing else {
+      throw NetworkError.refreshTokenExpired
+    }
+    
+    isRefreshing = true
+    defer { isRefreshing = false }
+    
+    guard tokenManager.refreshToken != nil else {
+      tokenManager.clearAll()
+      throw NetworkError.refreshTokenExpired
+    }
+    
+    let refreshRouter = AuthRouter.refreshToken
+    let tokenResponse = try await request(refreshRouter, type: TokenResponse.self)
+    
+    tokenManager.saveTokens(
+      accessToken: tokenResponse.accessToken,
+      refreshToken: tokenResponse.refreshToken
+    )
+    
+    try await requestWithoutResponse(router)
+  }
+  
+  // MARK: - Logging
+  
+#if DEBUG
+  private func logRequest(_ request: URLRequest) {
+    print("========== Network Request ==========")
+    print("[\(request.httpMethod ?? "UNKNOWN")] \(request.url?.absoluteString ?? "")")
+    print("Headers: \(request.allHTTPHeaderFields ?? [:])")
+    if let body = request.httpBody,
+       let bodyString = String(data: body, encoding: .utf8) {
+      print("Body: \(bodyString)")
+    }
+    print("======================================")
+  }
+  
+  private func logResponse(data: Data, response: URLResponse?) {
+    print("========== Network Response ==========")
+    if let httpResponse = response as? HTTPURLResponse {
+      print("Status Code: \(httpResponse.statusCode)")
+    }
+    if let dataString = String(data: data, encoding: .utf8) {
+      let truncated = dataString.prefix(500)
+      print("Data: \(truncated)\(dataString.count > 500 ? "..." : "")")
+    }
+    print("======================================")
+  }
+#endif
+}
+
+// MARK: - Token Response (임시, AuthDTO로 이동 예정)
+
+struct TokenResponse: Decodable {
+  let accessToken: String
+  let refreshToken: String
+}

--- a/Someverse/Core/Network/Manager/TokenManager.swift
+++ b/Someverse/Core/Network/Manager/TokenManager.swift
@@ -1,0 +1,178 @@
+//
+//  TokenManager.swift
+//  Someverse
+//
+//  Created by 박채현 on 12/10/25.
+//
+
+import Foundation
+import Security
+import Combine
+
+// MARK: - Token Manager
+
+final class TokenManager: ObservableObject {
+  static let shared = TokenManager()
+  
+  private let service = Bundle.main.bundleIdentifier ?? "com.someverse.app"
+  private let accessTokenKey = "SomeverseAccessToken"
+  private let refreshTokenKey = "SomeverseRefreshToken"
+  
+  private init() {}
+  
+  // MARK: - Token Properties
+  
+  var accessToken: String? {
+    get { getValue(forKey: accessTokenKey) }
+    set {
+      if let newValue = newValue {
+        setValue(newValue, forKey: accessTokenKey)
+      } else {
+        deleteValue(forKey: accessTokenKey)
+      }
+    }
+  }
+  
+  var refreshToken: String? {
+    get { getValue(forKey: refreshTokenKey) }
+    set {
+      if let newValue = newValue {
+        setValue(newValue, forKey: refreshTokenKey)
+      } else {
+        deleteValue(forKey: refreshTokenKey)
+      }
+    }
+  }
+  
+  // MARK: - Token Management
+  
+  func saveTokens(accessToken: String, refreshToken: String) {
+#if DEBUG
+    print("TokenManager: 토큰 저장 시작")
+#endif
+    self.accessToken = accessToken
+    self.refreshToken = refreshToken
+#if DEBUG
+    print("TokenManager: 토큰 저장 완료")
+#endif
+  }
+  
+  func clearTokens() {
+#if DEBUG
+    print("TokenManager: 토큰 삭제 시작")
+#endif
+    accessToken = nil
+    refreshToken = nil
+#if DEBUG
+    print("TokenManager: 토큰 삭제 완료")
+#endif
+  }
+  
+  func hasValidTokens() -> Bool {
+    let hasTokens = accessToken != nil && refreshToken != nil
+#if DEBUG
+    print("TokenManager: 토큰 존재 여부 - \(hasTokens)")
+#endif
+    return hasTokens
+  }
+  
+  // MARK: - Keychain Helper Methods
+  
+  private func setValue(_ value: String, forKey key: String) {
+    let data = Data(value.utf8)
+    
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: service,
+      kSecAttrAccount as String: key,
+      kSecValueData as String: data
+    ]
+    
+    // 기존 항목 삭제
+    SecItemDelete(query as CFDictionary)
+    
+    // 새 항목 추가
+    let status = SecItemAdd(query as CFDictionary, nil)
+#if DEBUG
+    if status != errSecSuccess {
+      print("Keychain 저장 실패 (\(key)): \(status)")
+    } else {
+      print("Keychain 저장 성공 (\(key))")
+    }
+#endif
+  }
+  
+  private func getValue(forKey key: String) -> String? {
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: service,
+      kSecAttrAccount as String: key,
+      kSecReturnData as String: true,
+      kSecMatchLimit as String: kSecMatchLimitOne
+    ]
+    
+    var item: CFTypeRef?
+    let status = SecItemCopyMatching(query as CFDictionary, &item)
+    
+    guard status == errSecSuccess,
+          let data = item as? Data,
+          let value = String(data: data, encoding: .utf8) else {
+#if DEBUG
+      if status == errSecItemNotFound {
+        print("Keychain: \(key) 데이터 없음")
+      } else if status != errSecSuccess {
+        print("Keychain 조회 실패 (\(key)): \(status)")
+      }
+#endif
+      return nil
+    }
+    return value
+  }
+  
+  private func deleteValue(forKey key: String) {
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: service,
+      kSecAttrAccount as String: key
+    ]
+    
+    let status = SecItemDelete(query as CFDictionary)
+#if DEBUG
+    if status != errSecSuccess && status != errSecItemNotFound {
+      print("Keychain 삭제 실패 (\(key)): \(status)")
+    } else {
+      print("Keychain 삭제 성공 (\(key))")
+    }
+#endif
+  }
+}
+
+// MARK: - User Info (JWT 디코딩 없이 서버에서 받은 정보 저장)
+
+extension TokenManager {
+  private static let userIdKey = "SomeverseUserId"
+  
+  var userId: String? {
+    get { getValue(forKey: Self.userIdKey) }
+    set {
+      if let newValue = newValue {
+        setValue(newValue, forKey: Self.userIdKey)
+      } else {
+        deleteValue(forKey: Self.userIdKey)
+      }
+    }
+  }
+  
+  func saveUserInfo(userId: String) {
+    self.userId = userId
+  }
+  
+  func clearUserInfo() {
+    userId = nil
+  }
+  
+  func clearAll() {
+    clearTokens()
+    clearUserInfo()
+  }
+}

--- a/Someverse/Core/Network/Middleware/NetworkMiddleware.swift
+++ b/Someverse/Core/Network/Middleware/NetworkMiddleware.swift
@@ -1,0 +1,127 @@
+//
+//  NetworkMiddleware.swift
+//  Someverse
+//
+//  Created by 박채현 on 12/10/25.
+//
+
+import Foundation
+
+final class NetworkMiddleware {
+  
+  private let tokenManager: TokenManager
+  
+  init(tokenManager: TokenManager = .shared) {
+    self.tokenManager = tokenManager
+  }
+  
+  // MARK: - Request Preparation
+  
+  func prepare(request: inout URLRequest, authorizationType: AuthorizationType) {
+    switch authorizationType {
+    case .none:
+      break
+      
+    case .apiKey:
+      // API 키 설정 (필요시 구현)
+      // request.setValue(APIKeys.someverse, forHTTPHeaderField: APIConstants.Header.apiKey)
+      break
+      
+    case .accessToken:
+      if let token = tokenManager.accessToken {
+        request.setValue("Bearer \(token)", forHTTPHeaderField: APIConstants.Header.authorization)
+      }
+      
+    case .refreshToken:
+      if let token = tokenManager.refreshToken {
+        request.setValue(token, forHTTPHeaderField: APIConstants.Header.refreshToken)
+      }
+      if let accessToken = tokenManager.accessToken {
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: APIConstants.Header.authorization)
+      }
+      
+    case .both:
+      // API 키 + 액세스 토큰
+      // request.setValue(APIKeys.someverse, forHTTPHeaderField: APIConstants.Header.apiKey)
+      if let token = tokenManager.accessToken {
+        request.setValue("Bearer \(token)", forHTTPHeaderField: APIConstants.Header.authorization)
+      }
+    }
+  }
+  
+  // MARK: - Response Handling
+  
+  func handleResponse(data: Data?, response: URLResponse?) throws -> Data {
+    guard let httpResponse = response as? HTTPURLResponse else {
+      throw NetworkError.invalidResponse
+    }
+    
+    guard let data = data else {
+      throw NetworkError.emptyData
+    }
+    
+#if DEBUG
+    print("NetworkMiddleware: 상태 코드 - \(httpResponse.statusCode)")
+#endif
+    
+    switch httpResponse.statusCode {
+    case 200...299:
+      return data
+      
+    case 400:
+      // 요청 바디에서 에러 메시지 파싱 시도
+      if let errorResponse = try? JSONDecoder().decode(ErrorResponse.self, from: data) {
+        throw NetworkError.customError(errorResponse.message)
+      }
+      throw NetworkError.badRequest
+      
+    case 401:
+      throw NetworkError.unauthorized
+      
+    case 403:
+      throw NetworkError.forbidden
+      
+    case 404:
+      throw NetworkError.notFound
+      
+    case 409:
+      // 충돌 (예: 닉네임 중복)
+      throw NetworkError.conflict
+      
+    case 418:
+      // 리프레시 토큰 만료 (커스텀)
+      throw NetworkError.refreshTokenExpired
+      
+    case 419:
+      // 액세스 토큰 만료 (커스텀)
+      throw NetworkError.accessTokenExpired
+      
+    case 429:
+      throw NetworkError.tooManyRequests
+      
+    case 500...599:
+      throw NetworkError.serverError
+      
+    default:
+      throw NetworkError.invalidStatusCode(httpResponse.statusCode)
+    }
+  }
+}
+
+// MARK: - Error Response Model
+
+struct ErrorResponse: Decodable {
+  let message: String
+  let code: String?
+  
+  enum CodingKeys: String, CodingKey {
+    case message
+    case code
+  }
+  
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    message = try container.decode(String.self, forKey: .message)
+    code = try container.decodeIfPresent(String.self, forKey: .code)
+  }
+}

--- a/Someverse/Core/Network/Router/AuthRouter.swift
+++ b/Someverse/Core/Network/Router/AuthRouter.swift
@@ -1,0 +1,81 @@
+//
+//  AuthRouter.swift
+//  Someverse
+//
+//  Created by 박채현 on 12/10/25.
+//
+
+import Foundation
+
+enum AuthRouter: APIRouter {
+  
+  case kakaoLogin(oauthToken: String, deviceToken: String)
+  case appleLogin(idToken: String, deviceToken: String, nickname: String?)
+  case refreshToken
+  case logout
+  
+  // MARK: - Path
+  
+  var path: String {
+    switch self {
+    case .kakaoLogin:
+      return APIConstants.Path.kakaoLogin
+    case .appleLogin:
+      return APIConstants.Path.appleLogin
+    case .refreshToken:
+      return APIConstants.Path.refresh
+    case .logout:
+      return APIConstants.Path.logout
+    }
+  }
+  
+  // MARK: - Method
+  
+  var method: HTTPMethod {
+    switch self {
+    case .kakaoLogin, .appleLogin, .logout:
+      return .post
+    case .refreshToken:
+      return .get
+    }
+  }
+  
+  // MARK: - Body
+  
+  var body: Data? {
+    switch self {
+    case .kakaoLogin(let oauthToken, let deviceToken):
+      let params: [String: Any] = [
+        "oauthToken": oauthToken,
+        "deviceToken": deviceToken
+      ]
+      return try? JSONSerialization.data(withJSONObject: params)
+      
+    case .appleLogin(let idToken, let deviceToken, let nickname):
+      var params: [String: Any] = [
+        "idToken": idToken,
+        "deviceToken": deviceToken
+      ]
+      if let nickname = nickname {
+        params["nickname"] = nickname
+      }
+      return try? JSONSerialization.data(withJSONObject: params)
+      
+    case .refreshToken, .logout:
+      return nil
+    }
+  }
+  
+  // MARK: - Authorization Type
+  
+  var authorizationType: AuthorizationType {
+    switch self {
+    case .kakaoLogin, .appleLogin:
+      return .none
+    case .refreshToken:
+      return .refreshToken
+    case .logout:
+      return .accessToken
+    }
+  }
+}

--- a/Someverse/Core/Network/Router/NetworkRouter.swift
+++ b/Someverse/Core/Network/Router/NetworkRouter.swift
@@ -1,0 +1,82 @@
+//
+//  NetworkRouter.swift
+//  Someverse
+//
+//  Created by 박채현 on 12/10/25.
+//
+
+import Foundation
+
+// MARK: - APIRouter Protocol
+
+protocol APIRouter {
+  var path: String { get }
+  var method: HTTPMethod { get }
+  var contentType: String { get }
+  var body: Data? { get }
+  var queryItems: [URLQueryItem]? { get }
+  var authorizationType: AuthorizationType { get }
+}
+
+// MARK: - HTTP Method
+
+enum HTTPMethod: String {
+  case get = "GET"
+  case post = "POST"
+  case put = "PUT"
+  case patch = "PATCH"
+  case delete = "DELETE"
+}
+
+// MARK: - Authorization Type
+
+enum AuthorizationType {
+  case none              // 인증 불필요
+  case apiKey            // API 키만
+  case accessToken       // 액세스 토큰
+  case refreshToken      // 리프레시 토큰
+  case both              // API 키 + 액세스 토큰
+}
+
+// MARK: - APIRouter Default Implementation
+
+extension APIRouter {
+  
+  var baseURL: URL? {
+    URL(string: APIConstants.baseURL)
+  }
+  
+  var contentType: String {
+    APIConstants.ContentType.json
+  }
+  
+  var queryItems: [URLQueryItem]? {
+    nil
+  }
+  
+  func asURLRequest() throws -> URLRequest {
+    guard let baseURL = baseURL else {
+      throw NetworkError.invalidURL
+    }
+    
+    var urlComponents = URLComponents(
+      url: baseURL.appendingPathComponent(path),
+      resolvingAgainstBaseURL: true
+    )
+    urlComponents?.queryItems = queryItems
+    
+    guard let url = urlComponents?.url else {
+      throw NetworkError.invalidURL
+    }
+    
+    var request = URLRequest(url: url)
+    request.httpMethod = method.rawValue
+    request.setValue(contentType, forHTTPHeaderField: APIConstants.Header.contentType)
+    
+    if let body = body {
+      request.httpBody = body
+    }
+    
+    return request
+  }
+}

--- a/Someverse/Core/Network/Router/UserRouter.swift
+++ b/Someverse/Core/Network/Router/UserRouter.swift
@@ -1,0 +1,90 @@
+//
+//  UserRouter.swift
+//  Someverse
+//
+//  Created by 박채현 on 12/10/25.
+//
+
+import Foundation
+
+enum UserRouter: APIRouter {
+  
+  case validateNickname(nickname: String)
+  case signUp(request: SignUpRequestDTO)
+  case getProfile
+  case updateProfile(request: ProfileUpdateRequestDTO)
+  case uploadProfileImage
+  
+  // MARK: - Path
+  
+  var path: String {
+    switch self {
+    case .validateNickname:
+      return APIConstants.Path.nicknameValidation
+    case .signUp:
+      return APIConstants.Path.signUp
+    case .getProfile, .updateProfile:
+      return APIConstants.Path.profile
+    case .uploadProfileImage:
+      return APIConstants.Path.profileImage
+    }
+  }
+  
+  // MARK: - Method
+  
+  var method: HTTPMethod {
+    switch self {
+    case .validateNickname:
+      return .get
+    case .signUp, .uploadProfileImage:
+      return .post
+    case .getProfile:
+      return .get
+    case .updateProfile:
+      return .put
+    }
+  }
+  
+  // MARK: - Query Items
+  
+  var queryItems: [URLQueryItem]? {
+    switch self {
+    case .validateNickname(let nickname):
+      return [URLQueryItem(name: "nickname", value: nickname)]
+    default:
+      return nil
+    }
+  }
+  
+  // MARK: - Body
+  
+  var body: Data? {
+    switch self {
+    case .signUp(let request):
+      let encoder = JSONEncoder()
+      encoder.keyEncodingStrategy = .convertToSnakeCase
+      return try? encoder.encode(request)
+      
+    case .updateProfile(let request):
+      let encoder = JSONEncoder()
+      encoder.keyEncodingStrategy = .convertToSnakeCase
+      return try? encoder.encode(request)
+      
+    default:
+      return nil
+    }
+  }
+  
+  // MARK: - Authorization Type
+  
+  var authorizationType: AuthorizationType {
+    switch self {
+    case .validateNickname:
+      return .none
+    case .signUp:
+      return .accessToken
+    case .getProfile, .updateProfile, .uploadProfileImage:
+      return .accessToken
+    }
+  }
+}

--- a/Someverse/Core/Nickname/NicknameClient.swift
+++ b/Someverse/Core/Nickname/NicknameClient.swift
@@ -48,6 +48,27 @@ extension NicknameClient: EnvironmentKey {
         },
         saveNickname: { _ in }
     )
+
+    /// 실제 네트워크 연동 Client
+    static let liveValue: NicknameClient = NicknameClient(
+        validateNickname: { nickname in
+            let router = UserRouter.validateNickname(nickname: nickname)
+            do {
+                let response = try await NetworkManager.shared.request(
+                    router,
+                    type: NicknameCheckResponse.self
+                )
+                return response.isAvailable ? .valid : .duplicate
+            } catch NetworkError.conflict {
+                return .duplicate
+            } catch {
+                return .invalid
+            }
+        },
+        saveNickname: { _ in
+            // 닉네임 저장은 회원가입 API에서 처리
+        }
+    )
 }
 
 extension EnvironmentValues {

--- a/Someverse/Core/SocialLogin/SocialLoginClient.swift
+++ b/Someverse/Core/SocialLogin/SocialLoginClient.swift
@@ -22,6 +22,22 @@ extension SocialLoginClient: EnvironmentKey {
         kakaoLogin: { SocialLoginModel.mock },
         appleLogin: { SocialLoginModel.mock }
     )
+
+    /// 실제 네트워크 연동 Client
+    static let liveValue: SocialLoginClient = SocialLoginClient(
+        kakaoLogin: {
+            let manager = KakaoLoginManager.shared
+            let oauthToken = try await manager.handleKakaoLogin()
+            let response = try await manager.completeLogin(oauthToken: oauthToken)
+            return SocialLoginModel(token: response.accessToken)
+        },
+        appleLogin: {
+            let manager = await AppleLoginManager.shared
+            let result = try await manager.handleAppleLogin()
+            let response = try await manager.completeLogin(idToken: result.idToken, nickname: result.nickname)
+            return SocialLoginModel(token: response.accessToken)
+        }
+    )
 }
 
 extension EnvironmentValues {


### PR DESCRIPTION
## 작업내용
1. 공통 DTO (CommonDTO.swift)
- APIResponse<T> 제네릭 응답 래퍼
- PageInfo, PaginatedResponse 페이징 처리

2. 도메인별 DTO 구현 (13개)
- AuthDTO: OAuth 로그인, 토큰 관리
- UserDTO: 온보딩, 프로필, 설정 (30+ 구조체)
- RegionDTO: 지역 목록
- GenreDTO: 장르 목록
- MovieDTO: 영화 검색/상세/온보딩
- TermsDTO: 약관 목록/상세
- FeedDTO: 피드 CRUD, 댓글, 좋아요
- ChatDTO: 채팅방, 메시지, 읽음 상태
- MatchingDTO: 일일 매칭, Like/Pass
- NotificationDTO: 알림 목록, FCM
- PointDTO: 포인트/루미 잔액, 거래 내역
- AnnouncementDTO: 공지사항
- FileDTO: Presigned URL, 파일 업로드

3. 기존 코드 통합
- AppleLoginManager, KakaoLoginManager: OAuthLoginResponse 연동
- NicknameClient: NicknameCheckResponse 연동
- UserRouter: SignUpRequestDTO, ProfileUpdateRequestDTO 호환성 유지

 4. 기타
- APIConstants.swift .gitignore에 추가

## 이슈번호
#6 